### PR TITLE
Have terraform notice if filters or templates are removed in the UI.

### DIFF
--- a/client/resource_feature.go
+++ b/client/resource_feature.go
@@ -136,12 +136,16 @@ func resourceFeatureRead(d *schema.ResourceData, m interface{}) error {
 		if err := d.Set("filter", feature.Filter.SQL); err != nil {
 			return err
 		}
+	} else {
+		d.Set("filter", nil)
 	}
 
 	if feature.TemplateID != nil {
 		if err := d.Set("template", strconv.Itoa(*feature.TemplateID)); err != nil {
 			return err
 		}
+	} else {
+		d.Set("template", nil)
 	}
 
 	if feature.Type == "event" {


### PR DESCRIPTION
I noticed that if I unlinked a feature from its template in the UI, terraform wouldn't try to update it.

This is required because golang doesn't support traversals over options.