### PR TITLE
AN-517: Refactor schema for destination references in feature stores

### DIFF
--- a/client/models.go
+++ b/client/models.go
@@ -255,11 +255,12 @@ type GCSStagingArea struct {
 
 // DestinationReference ...
 type DestinationReference struct {
-	Type          string `json:"adt_type"`
-	DestinationID int    `json:"destinationId"`
-	Folder        string `json:"folder,omitempty"`
-	TableName     string `json:"tableName,omitempty"`
-	Topic         string `json:"topic,omitempty"`
+	Type                      string `json:"adt_type"`
+	DestinationID             int    `json:"destinationId"`
+	Folder                    string `json:"folder,omitempty"`
+	FolderPartitioningEnabled *bool  `json:"folderPartitioningEnabled,omitempty"`
+	TableName                 string `json:"tableName,omitempty"`
+	Topic                     string `json:"topic,omitempty"`
 }
 
 // Cluster ...

--- a/example/main.tf
+++ b/example/main.tf
@@ -91,11 +91,11 @@ resource "anaml_table" "household_normalised" {
 }
 
 resource "anaml_feature_template" "household_count" {
-  name        = "household_count"
-  description = "Count of household items"
-  table       = anaml_table.household.id
-  select      = "count"
-  aggregation = "sum"
+  name                = "household_count"
+  description         = "Count of household items"
+  table               = anaml_table.household.id
+  select              = "count"
+  aggregation         = "sum"
   entity_restrictions = [anaml_entity.household.id]
 }
 
@@ -103,12 +103,12 @@ resource "anaml_feature" "household_count" {
   for_each = toset(["1", "2", "4"])
   days     = parseint(each.key, 10)
 
-  name        = "household_count_${each.key}_days"
-  description = "Count of household items"
-  table       = anaml_table.household.id
-  select      = "count"
-  aggregation = "sum"
-  template    = anaml_feature_template.household_count.id
+  name                = "household_count_${each.key}_days"
+  description         = "Count of household items"
+  table               = anaml_table.household.id
+  select              = "count"
+  aggregation         = "sum"
+  template            = anaml_feature_template.household_count.id
   entity_restrictions = anaml_feature_template.household_count.entity_restrictions
 }
 
@@ -142,8 +142,11 @@ resource "anaml-operations_feature_store" "household_daily" {
   enabled     = true
   cluster     = data.anaml-operations_cluster.local.id
   destination {
-    destination = data.anaml-operations_destination.s3a.id
-    folder      = "household_results"
+    destination                 = data.anaml-operations_destination.s3a.id
+    folder {
+      path = "household_results"
+      partitioning_enabled = true
+    }
   }
   daily_schedule {
     start_time_of_day = "00:00:00"
@@ -158,8 +161,11 @@ resource "anaml-operations_feature_store" "household_cron" {
   cluster           = data.anaml-operations_cluster.local.id
   entity_population = anaml_entity_population.adults.id
   destination {
-    destination = data.anaml-operations_destination.s3a.id
-    folder      = "household_results"
+    destination                 = data.anaml-operations_destination.s3a.id
+    folder {
+      path = "household_results"
+      partitioning_enabled = true
+    }
   }
   cron_schedule {
     cron_string = "* * * * *"
@@ -175,8 +181,11 @@ resource "anaml-operations_feature_store" "household_never" {
   enabled     = true
   cluster     = data.anaml-operations_cluster.local.id
   destination {
-    destination = data.anaml-operations_destination.s3a.id
-    folder      = "household_results"
+    destination                 = data.anaml-operations_destination.s3a.id
+    folder {
+      path = "household_results"
+      partitioning_enabled = true
+    }
   }
 }
 
@@ -187,8 +196,11 @@ resource "anaml-operations_feature_store" "household_daily_retry" {
   enabled     = true
   cluster     = data.anaml-operations_cluster.local.id
   destination {
-    destination = data.anaml-operations_destination.s3a.id
-    folder      = "household_results"
+    destination                 = data.anaml-operations_destination.s3a.id
+    folder {
+      path = "household_results"
+      partitioning_enabled = true
+    }
   }
   daily_schedule {
     start_time_of_day = "00:00:00"
@@ -207,8 +219,11 @@ resource "anaml-operations_feature_store" "household_cron_retry" {
   enabled     = true
   cluster     = data.anaml-operations_cluster.local.id
   destination {
-    destination = data.anaml-operations_destination.s3a.id
-    folder      = "household_results"
+    destination                 = data.anaml-operations_destination.s3a.id
+    folder {
+      path = "household_results"
+      partitioning_enabled = true
+    }
   }
   cron_schedule {
     cron_string = "* * * * *"


### PR DESCRIPTION
This schema change breaks compatibility. For any existing deployment, manual changes are needed to the state file. 
For any `resource.anaml-operations_feature_store` remove all destination properties excluding the id.

In this example section of the state file:
```
...
...
{
      "mode": "managed",
      "type": "anaml-operations_feature_store",
      "name": "household_cron",
      "provider": "provider[\"registry.anaml.io/anaml/anaml-operations\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "attribute": [],
            "cluster": "7",
            "cron_schedule": [
              {
                "cron_string": "* * * * *",
                "fixed_retry_policy": []
              }
            ],
            "daily_schedule": [],
            "description": "Daily view of households",
            "destination": [
              {
                "destination": "7",
                "folder": "household_results",
                "table_name": "",
                "topic": ""
              }
            ],
...
...
```
we would remove `folder`, `table_name` and `topic` but leaving `destination`.
Once these changes have been saved 
1) run `terraform refresh`