### PR TITLE
Use TypeSet for Labels and Attributes.

### DIFF
--- a/client/resource_cluster.go
+++ b/client/resource_cluster.go
@@ -56,7 +56,7 @@ func ResourceCluster() *schema.Resource {
 			},
 			"description": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"is_preview_cluster": {
 				Type:        schema.TypeBool,
@@ -87,7 +87,7 @@ func ResourceCluster() *schema.Resource {
 				Elem:        sparkServerSchema(),
 			},
 			"labels": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Labels to attach to the object",
 
@@ -96,7 +96,7 @@ func ResourceCluster() *schema.Resource {
 				},
 			},
 			"attribute": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Attributes (key value pairs) to attach to the object",
 				Elem:        attributeSchema(),
@@ -442,7 +442,7 @@ func composeCluster(d *schema.ResourceData) (*Cluster, error) {
 			AnamlServerURL:      local["anaml_server_url"].(string),
 			CredentialsProvider: credentialsProvider,
 			SparkConfig:         &sparkConfig,
-			Labels:              expandStringList(d.Get("labels").([]interface{})),
+			Labels:              expandLabels(d),
 			Attributes:          expandAttributes(d),
 		}
 		return &cluster, nil
@@ -456,7 +456,7 @@ func composeCluster(d *schema.ResourceData) (*Cluster, error) {
 			IsPreviewCluster: d.Get("is_preview_cluster").(bool),
 			SparkServerURL:   sparkServer["spark_server_url"].(string),
 			SparkConfig:      &sparkConfig,
-			Labels:           expandStringList(d.Get("labels").([]interface{})),
+			Labels:           expandLabels(d),
 			Attributes:       expandAttributes(d),
 		}
 		return &cluster, nil

--- a/client/resource_common.go
+++ b/client/resource_common.go
@@ -4,6 +4,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func labelSchema() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeString,
+	}
+}
+
+func expandLabels(d *schema.ResourceData) []string {
+	return expandStringList(d.Get("labels").(*schema.Set).List())
+}
+
 func attributeSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -20,7 +30,7 @@ func attributeSchema() *schema.Resource {
 }
 
 func expandAttributes(d *schema.ResourceData) []Attribute {
-	drs := d.Get("attribute").([]interface{})
+	drs := d.Get("attribute").(*schema.Set).List()
 	res := make([]Attribute, 0, len(drs))
 	for _, dr := range drs {
 		val, _ := dr.(map[string]interface{})

--- a/client/resource_destination.go
+++ b/client/resource_destination.go
@@ -43,7 +43,7 @@ func ResourceDestination() *schema.Resource {
 			},
 			"description": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"s3": {
 				Type:         schema.TypeList,
@@ -113,16 +113,13 @@ func ResourceDestination() *schema.Resource {
 				Elem:     snowflakeSourceDestinationSchema(),
 			},
 			"labels": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Labels to attach to the object",
-
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        labelSchema(),
 			},
 			"attribute": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Attributes (key value pairs) to attach to the object",
 				Elem:        attributeSchema(),
@@ -579,7 +576,7 @@ func composeDestination(d *schema.ResourceData) (*Destination, error) {
 			Bucket:      s3["bucket"].(string),
 			Path:        s3["path"].(string),
 			FileFormat:  fileFormat,
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 		}
 		return &destination, nil
@@ -597,7 +594,7 @@ func composeDestination(d *schema.ResourceData) (*Destination, error) {
 			AccessKey:   s3a["access_key"].(string),
 			SecretKey:   s3a["secret_key"].(string),
 			FileFormat:  fileFormat,
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 		}
 		return &destination, nil
@@ -621,7 +618,7 @@ func composeDestination(d *schema.ResourceData) (*Destination, error) {
 			URL:                 jdbc["url"].(string),
 			Schema:              jdbc["schema"].(string),
 			CredentialsProvider: credentialsProvider,
-			Labels:              expandStringList(d.Get("labels").([]interface{})),
+			Labels:              expandLabels(d),
 			Attributes:          expandAttributes(d),
 		}
 		return &destination, nil
@@ -633,7 +630,7 @@ func composeDestination(d *schema.ResourceData) (*Destination, error) {
 			Description: d.Get("description").(string),
 			Type:        "hive",
 			Database:    hive["database"].(string),
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 		}
 		return &destination, nil
@@ -651,7 +648,7 @@ func composeDestination(d *schema.ResourceData) (*Destination, error) {
 			Type:        "bigquery",
 			Path:        bigQuery["path"].(string),
 			StagingArea: stagingArea,
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 		}
 		return &destination, nil
@@ -666,7 +663,7 @@ func composeDestination(d *schema.ResourceData) (*Destination, error) {
 			Bucket:      gcs["bucket"].(string),
 			Path:        gcs["path"].(string),
 			FileFormat:  fileFormat,
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 		}
 		return &destination, nil
@@ -680,7 +677,7 @@ func composeDestination(d *schema.ResourceData) (*Destination, error) {
 			Type:        "local",
 			Path:        local["path"].(string),
 			FileFormat:  fileFormat,
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 		}
 		return &destination, nil
@@ -694,7 +691,7 @@ func composeDestination(d *schema.ResourceData) (*Destination, error) {
 			Type:        "hdfs",
 			Path:        hdfs["path"].(string),
 			FileFormat:  fileFormat,
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 		}
 		return &destination, nil
@@ -718,7 +715,7 @@ func composeDestination(d *schema.ResourceData) (*Destination, error) {
 			URL:                 online["url"].(string),
 			Schema:              online["schema"].(string),
 			CredentialsProvider: credentialsProvider,
-			Labels:              expandStringList(d.Get("labels").([]interface{})),
+			Labels:              expandLabels(d),
 			Attributes:          expandAttributes(d),
 		}
 		return &destination, nil
@@ -753,7 +750,7 @@ func composeDestination(d *schema.ResourceData) (*Destination, error) {
 			BootstrapServers:  kafka["bootstrap_servers"].(string),
 			SchemaRegistryURL: kafka["schema_registry_url"].(string),
 			KafkaProperties:   sensitives,
-			Labels:            expandStringList(d.Get("labels").([]interface{})),
+			Labels:            expandLabels(d),
 			Attributes:        expandAttributes(d),
 		}
 		return &destination, nil
@@ -779,7 +776,7 @@ func composeDestination(d *schema.ResourceData) (*Destination, error) {
 			Warehouse:           snowflake["warehouse"].(string),
 			Database:            snowflake["database"].(string),
 			CredentialsProvider: credentialsProvider,
-			Labels:              expandStringList(d.Get("labels").([]interface{})),
+			Labels:              expandLabels(d),
 			Attributes:          expandAttributes(d),
 		}
 		return &destination, nil

--- a/client/resource_entity.go
+++ b/client/resource_entity.go
@@ -43,7 +43,7 @@ func ResourceEntity() *schema.Resource {
 			},
 			"description": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"default_column": {
 				Type:         schema.TypeString,
@@ -61,16 +61,13 @@ func ResourceEntity() *schema.Resource {
 				},
 			},
 			"labels": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Labels to attach to the object",
-
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        labelSchema(),
 			},
 			"attribute": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Attributes (key value pairs) to attach to the object",
 				Elem:        attributeSchema(),
@@ -127,7 +124,7 @@ func buildEntity(d *schema.ResourceData) Entity {
 	entity := Entity{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
-		Labels:      expandStringList(d.Get("labels").([]interface{})),
+		Labels:      expandLabels(d),
 		Attributes:  expandAttributes(d),
 	}
 

--- a/client/resource_entity_population.go
+++ b/client/resource_entity_population.go
@@ -35,19 +35,16 @@ func ResourceEntityPopulation() *schema.Resource {
 			},
 			"description": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"labels": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Labels to attach to the object",
-
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        labelSchema(),
 			},
 			"attribute": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Attributes (key value pairs) to attach to the object",
 				Elem:        attributeSchema(),
@@ -155,7 +152,7 @@ func buildPopulation(d *schema.ResourceData) EntityPopulation {
 	return EntityPopulation{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
-		Labels:      expandStringList(d.Get("labels").([]interface{})),
+		Labels:      expandLabels(d),
 		Attributes:  expandAttributes(d),
 		Entity:      entity,
 		Expression:  d.Get("expression").(string),

--- a/client/resource_event_store.go
+++ b/client/resource_event_store.go
@@ -29,7 +29,7 @@ func ResourceEventStore() *schema.Resource {
 			},
 			"description": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"bootstrap_servers": {
 				Type:         schema.TypeString,
@@ -98,16 +98,13 @@ func ResourceEventStore() *schema.Resource {
 				Elem:        accessRuleSchema(),
 			},
 			"labels": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Labels to attach to the object",
-
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        labelSchema(),
 			},
 			"attribute": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Attributes (key value pairs) to attach to the object",
 				Elem:        attributeSchema(),
@@ -364,7 +361,7 @@ func buildEventStore(d *schema.ResourceData) (*EventStore, error) {
 		BatchIngestBaseURI: getNullableString(d, "batch_ingest_base_uri"),
 		ScatterBaseURI:     d.Get("scatter_base_uri").(string),
 		GlacierBaseURI:     d.Get("glacier_base_uri").(string),
-		Labels:             expandStringList(d.Get("labels").([]interface{})),
+		Labels:             expandLabels(d),
 		Attributes:         expandAttributes(d),
 		Cluster:            cluster,
 		Schedule:           schedule,

--- a/client/resource_feature.go
+++ b/client/resource_feature.go
@@ -131,16 +131,13 @@ func ResourceFeature() *schema.Resource {
 				ValidateFunc: validateAnamlIdentifier(),
 			},
 			"labels": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Labels to attach to the object",
-
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        labelSchema(),
 			},
 			"attribute": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Attributes (key value pairs) to attach to the object",
 				Elem:        attributeSchema(),
@@ -313,7 +310,7 @@ func buildFeature(d *schema.ResourceData) (*Feature, error) {
 		Aggregate: &AggregateExpression{
 			Type: d.Get("aggregation").(string),
 		},
-		Labels:     expandStringList(d.Get("labels").([]interface{})),
+		Labels:     expandLabels(d),
 		Attributes: expandAttributes(d),
 	}
 

--- a/client/resource_feature_set.go
+++ b/client/resource_feature_set.go
@@ -56,16 +56,13 @@ func ResourceFeatureSet() *schema.Resource {
 				},
 			},
 			"labels": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Labels to attach to the object",
-
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        labelSchema(),
 			},
 			"attribute": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Attributes (key value pairs) to attach to the object",
 				Elem:        attributeSchema(),
@@ -117,7 +114,7 @@ func resourceFeatureSetCreate(d *schema.ResourceData, m interface{}) error {
 		Description: d.Get("description").(string),
 		EntityID:    entity,
 		Features:    expandIdentifierList(d.Get("features").(*schema.Set).List()),
-		Labels:      expandStringList(d.Get("labels").([]interface{})),
+		Labels:      expandLabels(d),
 		Attributes:  expandAttributes(d),
 	}
 
@@ -140,7 +137,7 @@ func resourceFeatureSetUpdate(d *schema.ResourceData, m interface{}) error {
 		Description: d.Get("description").(string),
 		EntityID:    entity,
 		Features:    expandIdentifierList(d.Get("features").(*schema.Set).List()),
-		Labels:      expandStringList(d.Get("labels").([]interface{})),
+		Labels:      expandLabels(d),
 		Attributes:  expandAttributes(d),
 	}
 

--- a/client/resource_feature_store.go
+++ b/client/resource_feature_store.go
@@ -110,16 +110,13 @@ func ResourceFeatureStore() *schema.Resource {
 				ValidateFunc: validateAnamlIdentifier(),
 			},
 			"labels": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Labels to attach to the object",
-
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        labelSchema(),
 			},
 			"attribute": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Attributes (key value pairs) to attach to the object",
 				Elem:        attributeSchema(),
@@ -466,7 +463,7 @@ func composeFeatureStore(d *schema.ResourceData) (*FeatureStore, error) {
 		Cluster:         cluster,
 		Population:      population,
 		Schedule:        schedule,
-		Labels:          expandStringList(d.Get("labels").([]interface{})),
+		Labels:          expandLabels(d),
 		Attributes:      expandAttributes(d),
 		IncludeMetadata: d.Get("include_metadata").(bool),
 		VersionTarget:   versionTarget,

--- a/client/resource_feature_template.go
+++ b/client/resource_feature_template.go
@@ -41,7 +41,6 @@ func ResourceFeatureTemplate() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "root",
 			},
 			"table": {
 				Type:         schema.TypeString,
@@ -120,16 +119,13 @@ func ResourceFeatureTemplate() *schema.Resource {
 				RequiredWith: []string{"over"},
 			},
 			"labels": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Labels to attach to the object",
-
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        labelSchema(),
 			},
 			"attribute": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Attributes (key value pairs) to attach to the object",
 				Elem:        attributeSchema(),
@@ -293,7 +289,7 @@ func buildFeatureTemplate(d *schema.ResourceData) (*FeatureTemplate, error) {
 		Select: SQLExpression{
 			SQL: d.Get("select").(string),
 		},
-		Labels:     expandStringList(d.Get("labels").([]interface{})),
+		Labels:     expandLabels(d),
 		Attributes: expandAttributes(d),
 	}
 

--- a/client/resource_source.go
+++ b/client/resource_source.go
@@ -43,7 +43,7 @@ func ResourceSource() *schema.Resource {
 			},
 			"description": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"s3": {
 				Type:         schema.TypeList,
@@ -107,16 +107,13 @@ func ResourceSource() *schema.Resource {
 				Elem:     snowflakeSourceDestinationSchema(),
 			},
 			"labels": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Labels to attach to the object",
-
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        labelSchema(),
 			},
 			"attribute": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Attributes (key value pairs) to attach to the object",
 				Elem:        attributeSchema(),
@@ -966,7 +963,7 @@ func composeSource(d *schema.ResourceData) (*Source, error) {
 			Bucket:      s3["bucket"].(string),
 			Path:        s3["path"].(string),
 			FileFormat:  fileFormat,
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 			AccessRules: accessRules,
 		}
@@ -985,7 +982,7 @@ func composeSource(d *schema.ResourceData) (*Source, error) {
 			AccessKey:   s3a["access_key"].(string),
 			SecretKey:   s3a["secret_key"].(string),
 			FileFormat:  fileFormat,
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 			AccessRules: accessRules,
 		}
@@ -1010,7 +1007,7 @@ func composeSource(d *schema.ResourceData) (*Source, error) {
 			URL:                 jdbc["url"].(string),
 			Schema:              jdbc["schema"].(string),
 			CredentialsProvider: credentialsProvider,
-			Labels:              expandStringList(d.Get("labels").([]interface{})),
+			Labels:              expandLabels(d),
 			Attributes:          expandAttributes(d),
 			AccessRules:         accessRules,
 		}
@@ -1023,7 +1020,7 @@ func composeSource(d *schema.ResourceData) (*Source, error) {
 			Description: d.Get("description").(string),
 			Type:        "hive",
 			Database:    hive["database"].(string),
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 			AccessRules: accessRules,
 		}
@@ -1036,7 +1033,7 @@ func composeSource(d *schema.ResourceData) (*Source, error) {
 			Description: d.Get("description").(string),
 			Type:        "bigquery",
 			Path:        bigQuery["path"].(string),
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 			AccessRules: accessRules,
 		}
@@ -1052,7 +1049,7 @@ func composeSource(d *schema.ResourceData) (*Source, error) {
 			Bucket:      gcs["bucket"].(string),
 			Path:        gcs["path"].(string),
 			FileFormat:  fileFormat,
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 			AccessRules: accessRules,
 		}
@@ -1067,7 +1064,7 @@ func composeSource(d *schema.ResourceData) (*Source, error) {
 			Type:        "local",
 			Path:        local["path"].(string),
 			FileFormat:  fileFormat,
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 			AccessRules: accessRules,
 		}
@@ -1082,7 +1079,7 @@ func composeSource(d *schema.ResourceData) (*Source, error) {
 			Type:        "hdfs",
 			Path:        hdfs["path"].(string),
 			FileFormat:  fileFormat,
-			Labels:      expandStringList(d.Get("labels").([]interface{})),
+			Labels:      expandLabels(d),
 			Attributes:  expandAttributes(d),
 			AccessRules: accessRules,
 		}
@@ -1118,7 +1115,7 @@ func composeSource(d *schema.ResourceData) (*Source, error) {
 			BootstrapServers:  kafka["bootstrap_servers"].(string),
 			SchemaRegistryURL: kafka["schema_registry_url"].(string),
 			KafkaProperties:   sensitives,
-			Labels:            expandStringList(d.Get("labels").([]interface{})),
+			Labels:            expandLabels(d),
 			Attributes:        expandAttributes(d),
 			AccessRules:       accessRules,
 		}
@@ -1145,7 +1142,7 @@ func composeSource(d *schema.ResourceData) (*Source, error) {
 			Warehouse:           snowflake["warehouse"].(string),
 			Database:            snowflake["database"].(string),
 			CredentialsProvider: credentialsProvider,
-			Labels:              expandStringList(d.Get("labels").([]interface{})),
+			Labels:              expandLabels(d),
 			Attributes:          expandAttributes(d),
 			AccessRules:         accessRules,
 		}

--- a/client/resource_table.go
+++ b/client/resource_table.go
@@ -139,16 +139,13 @@ func ResourceTable() *schema.Resource {
 				},
 			},
 			"labels": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Labels to attach to the object",
-
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        labelSchema(),
 			},
 			"attribute": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Attributes (key value pairs) to attach to the object",
 				Elem:        attributeSchema(),
@@ -309,7 +306,7 @@ func buildTable(d *schema.ResourceData) *Table {
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
 		EventInfo:   expandEntityDescription(d),
-		Labels:      expandStringList(d.Get("labels").([]interface{})),
+		Labels:      expandLabels(d),
 		Attributes:  expandAttributes(d),
 	}
 

--- a/client/structure.go
+++ b/client/structure.go
@@ -15,7 +15,7 @@ import (
 var namePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 var identifierPattern = regexp.MustCompile(`^[0-9]+$`)
 
-// Takes the result of flatmap.Expand for an array of strings
+// Takes the result of flatmap. Expand for an array of strings
 // and returns a []string
 func expandStringList(configured []interface{}) []string {
 	vs := make([]string, 0, len(configured))


### PR DESCRIPTION
There's don't have an implicit order, and the server makes no
guarantees that they won't be reordered.

Also make description optional in the schemas.
