### PR TITLE
Make aws acces key, secret key and endpoint optional

### DIFF
--- a/client/resource_source.go
+++ b/client/resource_source.go
@@ -201,17 +201,17 @@ func s3aSourceDestinationSchema() *schema.Resource {
 			},
 			"endpoint": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			"access_key": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			"secret_key": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			"file_format": {


### PR DESCRIPTION
Refs: https://github.com/simple-machines/anaml-server/pull/711 / https://simplemachines.atlassian.net/browse/AN-954

Manually built and tested in the AWS deploy to verify it works (requires https://github.com/simple-machines/anaml-server/pull/711 for empty values)