### PR TITLE
Support Attributes for 'Users'.

### DIFF
--- a/client/resource_attribute_restriction.go
+++ b/client/resource_attribute_restriction.go
@@ -19,6 +19,7 @@ Multiple different types of attributes are supported:
 - Free Text
 - Boolean
 - Integer
+- User (Assign an Anaml user id to the attribute)
 `
 
 func ResourceAttributeRestriction() *schema.Resource {
@@ -47,7 +48,7 @@ func ResourceAttributeRestriction() *schema.Resource {
 				Optional:     true,
 				MaxItems:     1,
 				Elem:         enumAttributeSchema(),
-				ExactlyOneOf: []string{"enum", "freetext", "boolean", "integer"},
+				ExactlyOneOf: []string{"enum", "freetext", "boolean", "integer", "user"},
 			},
 			"freetext": {
 				Type:     schema.TypeList,
@@ -62,6 +63,12 @@ func ResourceAttributeRestriction() *schema.Resource {
 				Elem:     &schema.Resource{},
 			},
 			"integer": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     &schema.Resource{},
+			},
+			"user": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -159,6 +166,9 @@ func resourceAttributeRestrictionRead(d *schema.ResourceData, m interface{}) err
 	if err := d.Set("integer", buildEmpty(attribute.Type == "integerattribute")); err != nil {
 		return err
 	}
+	if err := d.Set("user", buildEmpty(attribute.Type == "userattribute")); err != nil {
+		return err
+	}
 	if err := d.Set("applies_to", mapTargetsToFrontend(attribute.AppliesTo)); err != nil {
 		return err
 	}
@@ -243,6 +253,10 @@ func composeAttribute(d *schema.ResourceData) (*AttributeRestriction, error) {
 		return &attribute, nil
 	}
 
+	if existsEmpty(d.Get("user").([]interface{})) {
+		attribute.Type = "userattribute"
+		return &attribute, nil
+	}
 	return nil, errors.New("Invalid attribute type")
 }
 

--- a/client/resource_attribute_restriction.go
+++ b/client/resource_attribute_restriction.go
@@ -20,6 +20,7 @@ Multiple different types of attributes are supported:
 - Boolean
 - Integer
 - User (Assign an Anaml user id to the attribute)
+- User Group (Assign an Anaml user group id to the attribute)
 `
 
 func ResourceAttributeRestriction() *schema.Resource {
@@ -48,7 +49,7 @@ func ResourceAttributeRestriction() *schema.Resource {
 				Optional:     true,
 				MaxItems:     1,
 				Elem:         enumAttributeSchema(),
-				ExactlyOneOf: []string{"enum", "freetext", "boolean", "integer", "user"},
+				ExactlyOneOf: []string{"enum", "freetext", "boolean", "integer", "user", "user_group"},
 			},
 			"freetext": {
 				Type:     schema.TypeList,
@@ -69,6 +70,12 @@ func ResourceAttributeRestriction() *schema.Resource {
 				Elem:     &schema.Resource{},
 			},
 			"user": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     &schema.Resource{},
+			},
+			"user_group": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -169,6 +176,9 @@ func resourceAttributeRestrictionRead(d *schema.ResourceData, m interface{}) err
 	if err := d.Set("user", buildEmpty(attribute.Type == "userattribute")); err != nil {
 		return err
 	}
+	if err := d.Set("user_group", buildEmpty(attribute.Type == "usergroupattribute")); err != nil {
+		return err
+	}
 	if err := d.Set("applies_to", mapTargetsToFrontend(attribute.AppliesTo)); err != nil {
 		return err
 	}
@@ -255,6 +265,11 @@ func composeAttribute(d *schema.ResourceData) (*AttributeRestriction, error) {
 
 	if existsEmpty(d.Get("user").([]interface{})) {
 		attribute.Type = "userattribute"
+		return &attribute, nil
+	}
+
+	if existsEmpty(d.Get("user_group").([]interface{})) {
+		attribute.Type = "usergroupattribute"
 		return &attribute, nil
 	}
 	return nil, errors.New("Invalid attribute type")


### PR DESCRIPTION
These allow one to specify a User Id as an attribute type, which
will display nicely in the UI.

These are particularly nice for things like 'owner' attributes,
where one can specify the owner of the feature.
