### PR TITLE
Add dependent schedules support

### DIFF
--- a/client/models.go
+++ b/client/models.go
@@ -1,5 +1,10 @@
 package anaml
 
+type AnamlObject struct {
+	ID   int    `json:"id"`
+	Type string `json:"adt_type"`
+}
+
 // Entity ..
 type Entity struct {
 	ID            int          `json:"id,omitempty"`
@@ -255,10 +260,11 @@ type MetricsJob struct {
 }
 
 type Schedule struct {
-	Type           string       `json:"adt_type"`
-	StartTimeOfDay *string      `json:"startTimeOfDay,omitempty"`
-	CronString     string       `json:"cronString,omitempty"`
-	RetryPolicy    *RetryPolicy `json:"retryPolicy,omitempty"`
+	Type           string        `json:"adt_type"`
+	StartTimeOfDay *string       `json:"startTimeOfDay,omitempty"`
+	CronString     string        `json:"cronString,omitempty"`
+	RetryPolicy    *RetryPolicy  `json:"retryPolicy,omitempty"`
+	DependentJobs  []AnamlObject `json:"dependentJobs,omitempty"`
 }
 
 type RetryPolicy struct {
@@ -674,6 +680,75 @@ func validRoles() []string {
 		"run_monitoring",
 		"super_user",
 		"view_reports",
+	}
+}
+
+func mapAnamlObjectToResource(v AnamlObject) (string, int) {
+	if v.Type == "anamlentitymapping" {
+		return "entity_mapping", v.ID
+	} else if v.Type == "anamlentity" {
+		return "entity", v.ID
+	} else if v.Type == "anamlentitypopulation" {
+		return "entity_population", v.ID
+	} else if v.Type == "anamleventstore" {
+		return "event_store", v.ID
+	} else if v.Type == "anamlfeature" {
+		return "feature", v.ID
+	} else if v.Type == "anamlfeaturetemplate" {
+		return "feature_template", v.ID
+	} else if v.Type == "anamlfeatureset" {
+		return "feature_set", v.ID
+	} else if v.Type == "anamlfeaturestore" {
+		return "feature_store", v.ID
+	} else if v.Type == "anamltable" {
+		return "table", v.ID
+	} else if v.Type == "anamltablecaching" {
+		return "caching", v.ID
+	} else if v.Type == "anamltablemonitoring" {
+		return "monitoring", v.ID
+	} else if v.Type == "anamlviewmaterialisation" {
+		return "view_materialisation_job", v.ID
+	} else if v.Type == "anamlmetricsset" {
+		return "metrics_set", v.ID
+	} else if v.Type == "anamlmetricsjob" {
+		return "metrics_job", v.ID
+	} else {
+		// Not a known resource, just show what it says.
+		return v.Type, v.ID
+	}
+}
+
+func mapResourceToAnamlObject(v string, i int) *AnamlObject {
+	if v == "entity_mapping" {
+		return &AnamlObject{Type: "anamlentitymapping", ID: i}
+	} else if v == "entity" {
+		return &AnamlObject{Type: "anamlentity", ID: i}
+	} else if v == "entity_population" {
+		return &AnamlObject{Type: "anamlentitypopulation", ID: i}
+	} else if v == "event_store" {
+		return &AnamlObject{Type: "anamleventstore", ID: i}
+	} else if v == "feature" {
+		return &AnamlObject{Type: "anamlfeature", ID: i}
+	} else if v == "feature_template" {
+		return &AnamlObject{Type: "anamlfeaturetemplate", ID: i}
+	} else if v == "feature_set" {
+		return &AnamlObject{Type: "anamlfeatureset", ID: i}
+	} else if v == "feature_store" {
+		return &AnamlObject{Type: "anamlfeaturestore", ID: i}
+	} else if v == "table" {
+		return &AnamlObject{Type: "anamltable", ID: i}
+	} else if v == "caching" {
+		return &AnamlObject{Type: "anamltablecaching", ID: i}
+	} else if v == "monitoring" {
+		return &AnamlObject{Type: "anamltablemonitoring", ID: i}
+	} else if v == "view_materialisation_job" {
+		return &AnamlObject{Type: "anamlviewmaterialisation", ID: i}
+	} else if v == "metrics_set" {
+		return &AnamlObject{Type: "anamlmetricsset", ID: i}
+	} else if v == "metrics_job" {
+		return &AnamlObject{Type: "anamlmetricsjob", ID: i}
+	} else {
+		return nil
 	}
 }
 

--- a/client/resource_event_store.go
+++ b/client/resource_event_store.go
@@ -77,14 +77,21 @@ func ResourceEventStore() *schema.Resource {
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          dailyScheduleSchema(),
-				ConflictsWith: []string{"cron_schedule"},
+				ConflictsWith: []string{"cron_schedule", "dependency_schedule"},
 			},
 			"cron_schedule": {
 				Type:          schema.TypeList,
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          cronScheduleSchema(),
-				ConflictsWith: []string{"daily_schedule"},
+				ConflictsWith: []string{"daily_schedule", "dependency_schedule"},
+			},
+			"dependency_schedule": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				Elem:          dependencyScheduleSchema(),
+				ConflictsWith: []string{"daily_schedule", "cron_schedule"},
 			},
 			"cluster": {
 				Type:         schema.TypeString,
@@ -229,7 +236,7 @@ func resourceEventStoreRead(d *schema.ResourceData, m interface{}) error {
 	if err := d.Set("access_rules", flattenAccessRules(entity.AccessRules)); err != nil {
 		return err
 	}
-	daily, cron, err := parseSchedule(entity.Schedule)
+	daily, cron, dependency, err := parseSchedule(entity.Schedule)
 	if err != nil {
 		return err
 	}
@@ -237,6 +244,9 @@ func resourceEventStoreRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	if err := d.Set("cron_schedule", cron); err != nil {
+		return err
+	}
+	if err := d.Set("dependency_schedule", dependency); err != nil {
 		return err
 	}
 	return err

--- a/client/resource_feature_store.go
+++ b/client/resource_feature_store.go
@@ -83,14 +83,21 @@ func ResourceFeatureStore() *schema.Resource {
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          dailyScheduleSchema(),
-				ConflictsWith: []string{"cron_schedule"},
+				ConflictsWith: []string{"cron_schedule", "dependency_schedule"},
 			},
 			"cron_schedule": {
 				Type:          schema.TypeList,
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          cronScheduleSchema(),
-				ConflictsWith: []string{"daily_schedule"},
+				ConflictsWith: []string{"daily_schedule", "dependency_schedule"},
+			},
+			"dependency_schedule": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				Elem:          dependencyScheduleSchema(),
+				ConflictsWith: []string{"daily_schedule", "cron_schedule"},
 			},
 			"destination": {
 				Type:     schema.TypeList,
@@ -242,7 +249,7 @@ func resourceFeatureStoreRead(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	daily, cron, err := parseSchedule(FeatureStore.Schedule)
+	daily, cron, dependency, err := parseSchedule(FeatureStore.Schedule)
 	if err != nil {
 		return err
 	}
@@ -250,6 +257,9 @@ func resourceFeatureStoreRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	if err := d.Set("cron_schedule", cron); err != nil {
+		return err
+	}
+	if err := d.Set("dependency_schedule", dependency); err != nil {
 		return err
 	}
 

--- a/client/resource_metrics_job.go
+++ b/client/resource_metrics_job.go
@@ -66,14 +66,21 @@ func ResourceMetricsJob() *schema.Resource {
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          dailyScheduleSchema(),
-				ConflictsWith: []string{"cron_schedule"},
+				ConflictsWith: []string{"cron_schedule", "dependency_schedule"},
 			},
 			"cron_schedule": {
 				Type:          schema.TypeList,
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          cronScheduleSchema(),
-				ConflictsWith: []string{"daily_schedule"},
+				ConflictsWith: []string{"daily_schedule", "dependency_schedule"},
+			},
+			"dependency_schedule": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				Elem:          dependencyScheduleSchema(),
+				ConflictsWith: []string{"daily_schedule", "cron_schedule"},
 			},
 			"destination": {
 				Type:     schema.TypeList,
@@ -159,7 +166,7 @@ func resourceMetricsJobRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	daily, cron, err := parseSchedule(MetricsJob.Schedule)
+	daily, cron, dependency, err := parseSchedule(MetricsJob.Schedule)
 	if err != nil {
 		return err
 	}
@@ -167,6 +174,9 @@ func resourceMetricsJobRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	if err := d.Set("cron_schedule", cron); err != nil {
+		return err
+	}
+	if err := d.Set("dependency_schedule", dependency); err != nil {
 		return err
 	}
 

--- a/client/resource_table_caching.go
+++ b/client/resource_table_caching.go
@@ -57,14 +57,21 @@ func ResourceTableCaching() *schema.Resource {
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          dailyScheduleSchema(),
-				ConflictsWith: []string{"cron_schedule"},
+				ConflictsWith: []string{"cron_schedule", "dependency_schedule"},
 			},
 			"cron_schedule": {
 				Type:          schema.TypeList,
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          cronScheduleSchema(),
-				ConflictsWith: []string{"daily_schedule"},
+				ConflictsWith: []string{"daily_schedule", "dependency_schedule"},
+			},
+			"dependency_schedule": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				Elem:          dependencyScheduleSchema(),
+				ConflictsWith: []string{"daily_schedule", "cron_schedule"},
 			},
 			"principal": {
 				Type:         schema.TypeString,
@@ -255,7 +262,7 @@ func resourceTableCachingRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("retainment", nil)
 	}
 
-	daily, cron, err := parseSchedule(TableCaching.Schedule)
+	daily, cron, dependency, err := parseSchedule(TableCaching.Schedule)
 	if err != nil {
 		return err
 	}
@@ -263,6 +270,9 @@ func resourceTableCachingRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	if err := d.Set("cron_schedule", cron); err != nil {
+		return err
+	}
+	if err := d.Set("dependency_schedule", dependency); err != nil {
 		return err
 	}
 

--- a/client/resource_table_monitoring.go
+++ b/client/resource_table_monitoring.go
@@ -56,14 +56,21 @@ func ResourceTableMonitoring() *schema.Resource {
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          dailyScheduleSchema(),
-				ConflictsWith: []string{"cron_schedule"},
+				ConflictsWith: []string{"cron_schedule", "dependency_schedule"},
 			},
 			"cron_schedule": {
 				Type:          schema.TypeList,
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          cronScheduleSchema(),
-				ConflictsWith: []string{"daily_schedule"},
+				ConflictsWith: []string{"daily_schedule", "dependency_schedule"},
+			},
+			"dependency_schedule": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				Elem:          dependencyScheduleSchema(),
+				ConflictsWith: []string{"daily_schedule", "cron_schedule"},
 			},
 			"cluster": {
 				Type:         schema.TypeString,
@@ -248,7 +255,7 @@ func resourceTableMonitoringRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	daily, cron, err := parseSchedule(TableMonitoring.Schedule)
+	daily, cron, dependency, err := parseSchedule(TableMonitoring.Schedule)
 	if err != nil {
 		return err
 	}
@@ -256,6 +263,9 @@ func resourceTableMonitoringRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	if err := d.Set("cron_schedule", cron); err != nil {
+		return err
+	}
+	if err := d.Set("dependency_schedule", dependency); err != nil {
 		return err
 	}
 

--- a/client/resource_view_materialisation_job.go
+++ b/client/resource_view_materialisation_job.go
@@ -50,14 +50,21 @@ func ResourceViewMaterialisationJob() *schema.Resource {
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          dailyScheduleSchema(),
-				ConflictsWith: []string{"cron_schedule"},
+				ConflictsWith: []string{"cron_schedule", "dependency_schedule"},
 			},
 			"cron_schedule": {
 				Type:          schema.TypeList,
 				Optional:      true,
 				MaxItems:      1,
 				Elem:          cronScheduleSchema(),
-				ConflictsWith: []string{"daily_schedule"},
+				ConflictsWith: []string{"daily_schedule", "dependency_schedule"},
+			},
+			"dependency_schedule": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				Elem:          dependencyScheduleSchema(),
+				ConflictsWith: []string{"daily_schedule", "cron_schedule"},
 			},
 			"usagettl": {
 				Type:         schema.TypeString,
@@ -158,7 +165,7 @@ func resourceViewMaterialisationJobRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	if ViewMaterialisationJob.Type == "batch" {
-		daily, cron, err := parseSchedule(ViewMaterialisationJob.Schedule)
+		daily, cron, dependency, err := parseSchedule(ViewMaterialisationJob.Schedule)
 		if err != nil {
 			return err
 		}
@@ -166,6 +173,9 @@ func resourceViewMaterialisationJobRead(d *schema.ResourceData, m interface{}) e
 			return err
 		}
 		if err := d.Set("cron_schedule", cron); err != nil {
+			return err
+		}
+		if err := d.Set("dependency_schedule", dependency); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Jobs can be scheduled to follow others when they are done, support this.

I've mapped anaml object types to the names of the resources which create them,
this gives a nicer API and a consistent feel when using the terraform client.

