### PR TITLE
Improve handling of CSV source fields.

### DIFF
--- a/client/resource_source.go
+++ b/client/resource_source.go
@@ -1253,13 +1253,13 @@ func composeFileFormat(d map[string]interface{}) *FileFormat {
 	}
 
 	if d["file_format"] == "csv" {
-		if compression, ok := d["compression"].(string); ok {
+		if compression, ok := d["compression"].(string); ok && compression != "" {
 			fileFormat.Compression = &compression
 		}
-		if dateFormat, ok := d["date_format"].(string); ok {
+		if dateFormat, ok := d["date_format"].(string); ok && dateFormat != "" {
 			fileFormat.DateFormat = &dateFormat
 		}
-		if emptyValue, ok := d["empty_value"].(string); ok {
+		if emptyValue, ok := d["empty_value"].(string); ok && emptyValue != "" {
 			fileFormat.EmptyValue = &emptyValue
 		}
 		if ignoreLeadingWhiteSpace, ok := d["ignore_leading_whitespace"].(bool); ok {
@@ -1274,13 +1274,13 @@ func composeFileFormat(d map[string]interface{}) *FileFormat {
 		if quoteAll, ok := d["quote_all"].(bool); ok {
 			fileFormat.QuoteAll = &quoteAll
 		}
-		if sep, ok := d["field_separator"].(string); ok {
+		if sep, ok := d["field_separator"].(string); ok && sep != "" {
 			fileFormat.Sep = &sep
 		}
-		if timestampFormat, ok := d["timestamp_format"].(string); ok {
+		if timestampFormat, ok := d["timestamp_format"].(string); ok && timestampFormat != "" {
 			fileFormat.TimestampFormat = &timestampFormat
 		}
-		if lineSep, ok := d["line_separator"].(string); ok {
+		if lineSep, ok := d["line_separator"].(string); ok && lineSep != "" {
 			fileFormat.LineSep = &lineSep
 		}
 	}


### PR DESCRIPTION
We're hit by [Terraform SDK Issue 258](https://github.com/hashicorp/terraform-plugin-sdk/issues/258)
here, which causes the elements of the nested structure to be
filled in even if it's not set in the record. This is a very
unfortunate part of the SDK.

Becase the map contains the empty string unconditionally and
we can't use GetOk like we could on the top level, we have to
check if the string is empty instead.

For boolean fields, we can't even do this properly, as it's
always false or true, so our optional elements in the Schema
will always be set, fortunately the Spark options will still
do the right thing here.
